### PR TITLE
Update rapidsnark

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -10,7 +10,7 @@ on:
       - develop
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v1

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -10,7 +10,7 @@ on:
       - develop
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v1

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: install golangci-lint
         run:
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.45.2
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.48.0
       - name: lint
         run: |
           go version

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -25,5 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests
-        run: go test -v -covermode=count
+        # noasm build tag is needed for older GitHub Action runners
+        run: go test -tags noasm -v -covermode=count
 

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.18.x ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         if: success()
@@ -25,6 +25,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests
-        # rapidsnark_noasm build tag is needed for older GitHub Action runners
-        run: go test -tags rapidsnark_noasm -v -covermode=count
+        run: go test -v -covermode=count
 

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.18.x ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Go
         if: success()

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests
-        # noasm build tag is needed for older GitHub Action runners
-        run: go test -tags noasm -v -covermode=count
+        # rapidsnark_noasm build tag is needed for older GitHub Action runners
+        run: go test -tags rapidsnark_noasm -v -covermode=count
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ run:
   # because GitHub has some amount of older hardware used for action runners.allow-parallel-runners.
   # For other platforms this flag is ignored
   build-tags:
-    - noasm
+    - rapidsnark_noasm
   skip-dirs:
     - vendor
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,11 @@ service:
 
 run:
   timeout: 2m
-  modules-download-mode: readonly
+  # On linux x86_64 use rapisnark version with disabled asm optimizations
+  # because GitHub has some amount of older hardware used for action runners.allow-parallel-runners.
+  # For other platforms this flag is ignored
+  build-tags:
+    - noasm
   skip-dirs:
     - vendor
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,9 @@
 service:
-  golangci-lint-version: 1.39.x
+  golangci-lint-version: 1.48.x
 
 run:
   timeout: 2m
+  modules-download-mode: readonly
   skip-dirs:
     - vendor
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,6 @@ service:
 
 run:
   timeout: 2m
-  # On linux x86_64 use rapisnark version with disabled asm optimizations
-  # because GitHub has some amount of older hardware used for action runners.allow-parallel-runners.
-  # For other platforms this flag is ignored
-  build-tags:
-    - rapidsnark_noasm
   skip-dirs:
     - vendor
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # jwz
 Golang implementation of json web zeroknowledge 
+
+### Usage on older hardware and in GitHub Actions
+You might need to switch to Ubuntu-22.04 for GHA and add `rapidsnark_noasm` build tag to your app build command, tests, linters, etc.
+
+```shell
+go build -tags rapidsnark_noasm
+go test -tags rapidsnark_noasm
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # jwz
 Golang implementation of json web zeroknowledge 
 
-### Usage on older hardware and in GitHub Actions
-You might need to switch to Ubuntu-22.04 for GHA and add `rapidsnark_noasm` build tag to your app build command, tests, linters, etc.
-
-```shell
-go build -tags rapidsnark_noasm
-go test -tags rapidsnark_noasm
-```
+### Notes on prover optimization for x86_64 hardware
+See readme in [iden3/go-rapidsnark/prover](https://github.com/iden3/go-rapidsnark/blob/main/prover/)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.4
+	github.com/iden3/go-rapidsnark/prover v0.0.5
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c
+	github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2
+	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2
+	github.com/iden3/go-rapidsnark/prover v0.0.3
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1
@@ -26,4 +26,3 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286
+	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.1
+	github.com/iden3/go-rapidsnark/prover v0.0.2
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.3
+	github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8
+	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1
@@ -26,3 +26,7 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+//replace (
+//	github.com/iden3/go-rapidsnark/prover v0.0.2 => ../go-rapidsnark/prover
+//)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86
+	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1
@@ -28,5 +28,5 @@ require (
 )
 
 //replace (
-//	github.com/iden3/go-rapidsnark/prover v0.0.2 => ../go-rapidsnark/prover
+//	github.com/iden3/go-rapidsnark/prover => ../go-rapidsnark/prover
 //)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2
+	github.com/iden3/go-rapidsnark/prover v0.0.4
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/iden3/go-circuits v0.1.0
 	github.com/iden3/go-iden3-crypto v0.0.13
-	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2
+	github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2
 	github.com/iden3/go-rapidsnark/types v0.0.1
 	github.com/iden3/go-rapidsnark/verifier v0.0.1
 	github.com/iden3/go-rapidsnark/witness v0.0.1
@@ -27,6 +27,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-//replace (
-//	github.com/iden3/go-rapidsnark/prover => ../go-rapidsnark/prover
-//)

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2 h1:v4l6BEyMRHzcHr8xcgI/NjyDvJhyNR09vFR+8xNwst0=
-github.com/iden3/go-rapidsnark/prover v0.0.2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286 h1:oMIAGLeVp+xzFpNszxARJbqrSFgOIAKs0A0YfG6otpc=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=
@@ -220,13 +220,16 @@ github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH6
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -548,6 +551,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2 h1:dHRLI4FjsjGuMaY3rCXl5SuGJEejbQr7ZA137UOQlQ4=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.3 h1:iyw9mRbAWZCKC0aLkHnpGItSX75Zd0fgupaiAV7NzyI=
+github.com/iden3/go-rapidsnark/prover v0.0.3/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86 h1:fvDxUOGzEIsBi4k5t9x/zYAlGKntEwIXn13RbC6sBfQ=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2 h1:X2tUUwTbfu2elDE/pWNSHj+T3OCk5qJws7OChr/trQA=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.1 h1:vohLZNecoZfBPWliGU/axzVGMmX2k4TwevCDWCfa8cs=
-github.com/iden3/go-rapidsnark/prover v0.0.1/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2 h1:v4l6BEyMRHzcHr8xcgI/NjyDvJhyNR09vFR+8xNwst0=
+github.com/iden3/go-rapidsnark/prover v0.0.2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=
@@ -220,16 +220,13 @@ github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH6
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
-github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -551,7 +548,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2 h1:cjzPNeknEY0GoTknc5SWHC+AdQdfzDHPe/DChmejDls=
-github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.4 h1:Mk611S18tnDcx4KAtikKF5oVGLDm+JNNf70tzVxLVBg=
+github.com/iden3/go-rapidsnark/prover v0.0.4/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.3 h1:iyw9mRbAWZCKC0aLkHnpGItSX75Zd0fgupaiAV7NzyI=
-github.com/iden3/go-rapidsnark/prover v0.0.3/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c h1:RrfwWm43O5zqyJnKdU/YsosAkVy9B3ivCkZul3og08w=
+github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286 h1:oMIAGLeVp+xzFpNszxARJbqrSFgOIAKs0A0YfG6otpc=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812160943-612e70436286/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8 h1:4wtuzA2gNrnMy76TgvpaTxSsu67DTkjt0rBBseQBorQ=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2 h1:X2tUUwTbfu2elDE/pWNSHj+T3OCk5qJws7OChr/trQA=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812212251-7983dbc6b4f2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2 h1:dHRLI4FjsjGuMaY3rCXl5SuGJEejbQr7ZA137UOQlQ4=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220825165610-4e211b8ed7a2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.4 h1:Mk611S18tnDcx4KAtikKF5oVGLDm+JNNf70tzVxLVBg=
-github.com/iden3/go-rapidsnark/prover v0.0.4/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.5 h1:8/qEuiBUnp9yLy6CdXgQgcrf6m1JIeKJAnn2v+etahw=
+github.com/iden3/go-rapidsnark/prover v0.0.5/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c h1:RrfwWm43O5zqyJnKdU/YsosAkVy9B3ivCkZul3og08w=
-github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220828232908-ca2d7e82584c/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2 h1:cjzPNeknEY0GoTknc5SWHC+AdQdfzDHPe/DChmejDls=
+github.com/iden3/go-rapidsnark/prover v0.0.4-0.20220829001537-985b9c761cc2/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/iden3/go-iden3-crypto v0.0.13 h1:ixWRiaqDULNyIDdOWz2QQJG5t4PpNHkQk2P6
 github.com/iden3/go-iden3-crypto v0.0.13/go.mod h1:swXIv0HFbJKobbQBtsB50G7IHr6PbTowutSew/iBEoo=
 github.com/iden3/go-merkletree-sql v1.0.1 h1:zZMhhyV6FLoLL+pHQiiPoAI3ORSCTKOL32/n7Sb/+R4=
 github.com/iden3/go-merkletree-sql v1.0.1/go.mod h1:NhLFvX01F/3QqS0FUkC6T2BXPksz+9EbRhKQ7abaBSE=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8 h1:4wtuzA2gNrnMy76TgvpaTxSsu67DTkjt0rBBseQBorQ=
-github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812161354-31e47a1c8ab8/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86 h1:fvDxUOGzEIsBi4k5t9x/zYAlGKntEwIXn13RbC6sBfQ=
+github.com/iden3/go-rapidsnark/prover v0.0.2-0.20220812203643-0d0d0a91ac86/go.mod h1:r4nFKxoKNqc9CUK0pi1lACWdws4gl2lXc6tu5qaA5PE=
 github.com/iden3/go-rapidsnark/types v0.0.1 h1:WTGzdFXKlKo0CzVk1jyN4FsTDKdR+EPfn2wR3pdeXKQ=
 github.com/iden3/go-rapidsnark/types v0.0.1/go.mod h1:ApgcaUxKIgSRA6fAeFxK7p+lgXXfG4oA2HN5DhFlfF4=
 github.com/iden3/go-rapidsnark/verifier v0.0.1 h1:CQd2C6F49oxZlyLLHN0N8fnZU5FqxYwW7qCrreL394Y=

--- a/jwz.go
+++ b/jwz.go
@@ -47,10 +47,7 @@ func NewWithPayload(prover ProvingMethod, payload []byte, inputsPreparer ProofIn
 		Method:         prover,
 		inputsPreparer: inputsPreparer,
 	}
-	err := token.setDefaultHeaders(prover.Alg(), prover.CircuitID())
-	if err != nil {
-		return nil, err
-	}
+	token.setDefaultHeaders(prover.Alg(), prover.CircuitID())
 	token.setPayload(payload)
 
 	return token, nil
@@ -65,7 +62,7 @@ type rawJSONWebZeroknowledge struct {
 }
 
 // setHeader set headers for jwz
-func (token *Token) setDefaultHeaders(zkpAlg, circuitID string) error {
+func (token *Token) setDefaultHeaders(zkpAlg, circuitID string) {
 	headers := map[HeaderKey]interface{}{
 		headerAlg:       zkpAlg,
 		headerCritical:  []HeaderKey{headerCircuitID},
@@ -74,7 +71,6 @@ func (token *Token) setDefaultHeaders(zkpAlg, circuitID string) error {
 	}
 
 	token.raw.Header = headers
-	return nil
 }
 
 // WithHeader allows to set or redefine default headers

--- a/jwz.go
+++ b/jwz.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/iden3/go-circuits"
 	"github.com/iden3/go-rapidsnark/types"
-	"strings"
 )
 
 // HeaderKey represents type for jwz headers keys


### PR DESCRIPTION
Switched to new optimized rapidsnark.
Added `rapidsnark_noasm` build tag and newer ubuntu to use in GitHub Actions.