### PR TITLE
add getter for header of jwz token

### DIFF
--- a/jwz.go
+++ b/jwz.go
@@ -79,6 +79,11 @@ func (token *Token) WithHeader(key HeaderKey, value interface{}) error {
 	return nil
 }
 
+// GetHeader returns header
+func (token *Token) GetHeader() map[HeaderKey]interface{} {
+	return token.raw.Header
+}
+
 // setPayload  set payload for jwz
 func (token *Token) setPayload(payload []byte) {
 	token.raw.Payload = payload


### PR DESCRIPTION
Add `GetHeader` getter to get the header of the JWZ token.

While building on top of the library, other fields might be required apart from those provided by type `Token`. This PR adds a getter to achieve the same.